### PR TITLE
Fix lint: upgrade to support go1.22

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,29 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - master
+      - release-0.31
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  GO_VERSION: v1.22
+  GOLANGCI_LINT_VERSION: v1.56
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          args: --verbose

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,5 @@
 run:
-  timeout: 3m
+  timeout: 5m
   skip-dirs:
   - vendor
 linters:

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ endif
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 INSTALL_LOCATION:=$(shell go env GOPATH)/bin
-GOLANGCI_LINT_VERSION ?= 1.54.0
+GOLANGCI_LINT_VERSION ?= 1.56.2
 GOSEC_VERSION ?= 2.13.1
 
 REGISTRY ?= gcr.io/$(shell gcloud config get-value project)

--- a/cmd/agent/app/server.go
+++ b/cmd/agent/app/server.go
@@ -61,7 +61,7 @@ func NewAgentCommand(a *Agent, o *options.GrpcProxyAgentOptions) *cobra.Command 
 	cmd := &cobra.Command{
 		Use:  "agent",
 		Long: `A gRPC agent, Connects to the proxy and then allows traffic to be forwarded to it.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			drainCh, stopCh := SetupSignalHandler()
 			return a.Run(o, drainCh, stopCh)
 		},
@@ -182,7 +182,7 @@ func (a *Agent) runProxyConnection(o *options.GrpcProxyAgentOptions, drainCh, st
 }
 
 func (a *Agent) runHealthServer(o *options.GrpcProxyAgentOptions, cs agent.ReadinessManager) error {
-	livenessHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	livenessHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintf(w, "ok")
 	})
 

--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -64,7 +64,7 @@ func NewProxyCommand(p *Proxy, o *options.ProxyRunOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:  "proxy",
 		Long: `A gRPC proxy server, receives requests from the API server and forwards to the agent.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			stopCh := SetupSignalHandler()
 			return p.Run(o, stopCh)
 		},
@@ -451,10 +451,10 @@ func (p *Proxy) runAdminServer(o *options.ProxyRunOptions, _ *server.ProxyServer
 }
 
 func (p *Proxy) runHealthServer(o *options.ProxyRunOptions, server *server.ProxyServer) error {
-	livenessHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	livenessHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintf(w, "ok")
 	})
-	readinessHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	readinessHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		ready, msg := server.Readiness.Ready()
 		if ready {
 			w.WriteHeader(200)

--- a/cmd/test-client/main.go
+++ b/cmd/test-client/main.go
@@ -216,7 +216,7 @@ func newGrpcProxyClientCommand(c *Client, o *GrpcProxyClientOptions) *cobra.Comm
 	cmd := &cobra.Command{
 		Use:  "proxy-client",
 		Long: `A gRPC proxy Client, primarily used to test the Kubernetes gRPC Proxy Server.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			cmd.SilenceUsage = true
 			return c.run(o)
 		},
@@ -479,7 +479,7 @@ func (c *Client) getUDSDialer(o *GrpcProxyClientOptions) (func(ctx context.Conte
 		return nil, fmt.Errorf("failed to process mode %s", o.mode)
 	}
 
-	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return func(_ context.Context, _, _ string) (net.Conn, error) {
 		return proxyConn, nil
 	}, nil
 }
@@ -556,7 +556,7 @@ func (c *Client) getMTLSDialer(o *GrpcProxyClientOptions) (func(ctx context.Cont
 		return nil, fmt.Errorf("failed to process mode %s", o.mode)
 	}
 
-	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return func(_ context.Context, _, _ string) (net.Conn, error) {
 		return proxyConn, nil
 	}, nil
 }

--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -89,7 +89,7 @@ func newTestServerCommand(p *TestServer, o *TestServerRunOptions) *cobra.Command
 	cmd := &cobra.Command{
 		Use:  "test http server",
 		Long: `A test http server, url determines behavior for certain tests.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return p.run(o)
 		},
 	}

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -553,14 +553,14 @@ func (a *Client) remoteToProxy(connID int64, eConn *endpointConn) {
 				klog.ErrorS(err, "connection read failure", "connectionID", connID)
 			}
 			return
-		} else {
-			resp.Payload = &client.Packet_Data{Data: &client.Data{
-				Data:      buf[:n],
-				ConnectID: connID,
-			}}
-			if err := a.Send(resp); err != nil {
-				klog.ErrorS(err, "could not send DATA", "connectionID", connID)
-			}
+		}
+
+		resp.Payload = &client.Packet_Data{Data: &client.Data{
+			Data:      buf[:n],
+			ConnectID: connID,
+		}}
+		if err := a.Send(resp); err != nil {
+			klog.ErrorS(err, "could not send DATA", "connectionID", connID)
 		}
 	}
 }

--- a/pkg/agent/client_test.go
+++ b/pkg/agent/client_test.go
@@ -54,7 +54,7 @@ func TestServeData_HTTP(t *testing.T) {
 
 	// Start test http server as remote service
 	expectedBody := "Hello, client"
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(w, expectedBody)
 	}))
 	defer ts.Close()
@@ -152,7 +152,7 @@ func TestClose_Client(t *testing.T) {
 	defer close(stopCh)
 
 	// Start test http server as remote service
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(w, "hello, world")
 	}))
 	defer ts.Close()

--- a/pkg/server/backend_manager.go
+++ b/pkg/server/backend_manager.go
@@ -287,9 +287,9 @@ func NewDefaultBackendStorage(idTypes []header.IdentifierType) *DefaultBackendSt
 	metrics.Metrics.SetBackendCount(0)
 	return &DefaultBackendStorage{
 		backends: make(map[string][]*Backend),
-		random:   rand.New(rand.NewSource(time.Now().UnixNano())),
+		random:   rand.New(rand.NewSource(time.Now().UnixNano())), /* #nosec G404 */
 		idTypes:  idTypes,
-	} /* #nosec G404 */
+	}
 }
 
 func containIDType(idTypes []header.IdentifierType, idType header.IdentifierType) bool {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -132,9 +132,8 @@ func (c *ProxyClientConnection) send(pkt *client.Packet) error {
 				return c.CloseHTTP()
 			}
 			return nil
-		} else {
-			return fmt.Errorf("attempt to send via unrecognized connection type %v", pkt.Type)
 		}
+		return fmt.Errorf("attempt to send via unrecognized connection type %v", pkt.Type)
 	}
 	return fmt.Errorf("attempt to send via unrecognized connection mode %q", c.Mode)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -137,7 +137,7 @@ func TestAgentTokenAuthenticationErrorsToken(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			kcs := k8sfake.NewSimpleClientset()
 
-			kcs.AuthenticationV1().(*fakeauthenticationv1.FakeAuthenticationV1).Fake.PrependReactor("create", "tokenreviews", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			kcs.AuthenticationV1().(*fakeauthenticationv1.FakeAuthenticationV1).Fake.PrependReactor("create", "tokenreviews", func(_ k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 				tr := &authv1.TokenReview{
 					Status: authv1.TokenReviewStatus{
 						Authenticated: tc.authenticated,
@@ -809,7 +809,7 @@ func TestServerProxyRecvChanFull(t *testing.T) {
 }
 
 func TestServerProxyNoDial(t *testing.T) {
-	baseServerProxyTestWithBackend(t, func(frontendConn, agentConn *agentmock.MockAgentService_ConnectServer) {
+	baseServerProxyTestWithBackend(t, func(frontendConn, _ *agentmock.MockAgentService_ConnectServer) {
 		const connectID = 123456
 		data := &client.Packet{
 			Type: client.PacketType_DATA,

--- a/tests/agent_disconnect_test.go
+++ b/tests/agent_disconnect_test.go
@@ -216,7 +216,7 @@ func createHTTPConnectClient(_ context.Context, proxyAddr, addr string) (*http.C
 		return nil, fmt.Errorf("unexpected extra buffer")
 	}
 
-	dialer := func(network, addr string) (net.Conn, error) {
+	dialer := func(_, _ string) (net.Conn, error) {
 		return conn, nil
 	}
 

--- a/tests/custom_alpn_test.go
+++ b/tests/custom_alpn_test.go
@@ -40,7 +40,7 @@ func TestCustomALPN(t *testing.T) {
 	svr := httptest.NewUnstartedServer(http.DefaultServeMux)
 	svr.TLS = &tls.Config{NextProtos: []string{proto}, MinVersion: tls.VersionTLS13}
 	svr.Config.TLSNextProto = map[string]func(*http.Server, *tls.Conn, http.Handler){
-		proto: func(svr *http.Server, conn *tls.Conn, handle http.Handler) {
+		proto: func(*http.Server, *tls.Conn, http.Handler) {
 			atomic.AddInt32(&protoUsed, 1)
 		},
 	}

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -362,7 +362,7 @@ func TestProxyDial_RequestCancelled_Concurrent_GRPC(t *testing.T) {
 	waitForConnectedServerCount(t, 1, a)
 
 	wg := sync.WaitGroup{}
-	dialFn := func(id int, cancelDelay time.Duration) {
+	dialFn := func(_ int, cancelDelay time.Duration) {
 		defer wg.Done()
 
 		// run test client
@@ -615,7 +615,7 @@ func TestBasicProxy_HTTPCONN(t *testing.T) {
 		t.Error("unexpected extra buffer")
 	}
 
-	dialer := func(network, addr string) (net.Conn, error) {
+	dialer := func(_, _ string) (net.Conn, error) {
 		return conn, nil
 	}
 
@@ -679,7 +679,7 @@ func TestFailedDNSLookupProxy_HTTPCONN(t *testing.T) {
 	if br.Buffered() > 0 {
 		t.Error("unexpected extra buffer")
 	}
-	dialer := func(network, addr string) (net.Conn, error) {
+	dialer := func(_, _ string) (net.Conn, error) {
 		return conn, nil
 	}
 
@@ -753,7 +753,7 @@ func TestFailedDial_HTTPCONN(t *testing.T) {
 		t.Fatalf("expect 200; got %d", res.StatusCode)
 	}
 
-	dialer := func(network, addr string) (net.Conn, error) {
+	dialer := func(_, _ string) (net.Conn, error) {
 		return conn, nil
 	}
 


### PR DESCRIPTION
golangci-lint supports go1.22 since v1.56.0, per https://github.com/golangci/golangci-lint/issues/4273.

Switch to using Github Actions for lint check.